### PR TITLE
Flip exit code values

### DIFF
--- a/revoke-test/tests/system_tests.rs
+++ b/revoke-test/tests/system_tests.rs
@@ -69,7 +69,7 @@ fn test_low_level_cli(sites: Vec<RevocationTestSite>) {
         println!("duration: {time_taken:?}");
 
         match e.status.code() {
-            Some(1) => {
+            Some(2) => {
                 assert_eq!(e.stdout, b"CertainlyRevoked\n");
                 correctly_revoked += 1;
             }

--- a/upki/src/main.rs
+++ b/upki/src/main.rs
@@ -154,5 +154,5 @@ enum Command {
     ShowConfig,
 }
 
-const EXIT_CODE_REVOCATION_REVOKED: u8 = 1;
-const EXIT_CODE_REVOCATION_ERROR: u8 = 2;
+const EXIT_CODE_REVOCATION_REVOKED: u8 = 2;
+const EXIT_CODE_REVOCATION_ERROR: u8 = 1;


### PR DESCRIPTION
Don't know how intentional you were about the selection of these exit codes? Because `ExitCode::FAILURE` is generally 1, `Err::<Report>(..)` will yield an exit code of 1, so if we want to present `REVOKED` as a special exit code, it would be more helpful to report it as 2.

GNU libc [documents](https://www.gnu.org/software/libc/manual/html_node/Exit-Status.html):

> There are conventions for what sorts of status values certain programs should return. The most common convention is simply 0 for success and 1 for failure. Programs that perform comparison use a different convention: they use status 1 to indicate a mismatch, and status 2 to indicate an inability to compare. Your program should follow an existing convention if an existing convention makes sense for it.

The previous usage kind of fits with the "comparison" convention.

Claude says:

> ### Core Conventions
> 0 means success - the program completed normally without errors.
> 1-125 are available for programs to define their own error meanings. Many programs use:
> 
> 1 for general errors
> 2 for misuse of shell commands (like wrong number of arguments)
> 
> 126 means the command cannot execute (like permission denied on a script).
> 127 means command not found.
> 128+N indicates the process was terminated by signal N. For example:
> 
> 130 (128+2) means terminated by SIGINT (Ctrl+C)
> 137 (128+9) means killed by SIGKILL
> 143 (128+15) means terminated by SIGTERM
> 
> ### Practical Guidance
> When writing programs, you should:
> 
> Return 0 on success
> Return non-zero on any kind of failure
> Consider using distinct codes for different error categories if callers need to distinguish them
> Stay away from codes 126+ to avoid conflicts with shell conventions

Which suggests we may want another value than 2 for this.

There's also the `sysexits.h` values:

```
       #include <sysexits.h>
       #define EX_OK           0    /* successful termination */

       #define EX__BASE        64   /* base value for error messages */

       #define EX_USAGE        64   /* command line usage error */
       #define EX_DATAERR      65   /* data format error */
       #define EX_NOINPUT      66   /* cannot open input */
       #define EX_NOUSER       67   /* addressee unknown */
       #define EX_NOHOST       68   /* host name unknown */
       #define EX_UNAVAILABLE  69   /* service unavailable */
       #define EX_SOFTWARE     70   /* internal software error */
       #define EX_OSERR        71   /* system error (e.g., can't fork) */
       #define EX_OSFILE       72   /* critical OS file missing */
       #define EX_CANTCREAT    73   /* can't create (user) output file */
       #define EX_IOERR        74   /* input/output error */
       #define EX_TEMPFAIL     75   /* temp failure; user is invited to
                                       retry */
       #define EX_PROTOCOL     76   /* remote error in protocol */
       #define EX_NOPERM       77   /* permission denied */
       #define EX_CONFIG       78   /* configuration error */

       #define EX__MAX         ...  /* maximum listed value */
```