### PR TITLE
upki: use kebab-case for config keys

### DIFF
--- a/revoke-test/tests/system_tests.rs
+++ b/revoke-test/tests/system_tests.rs
@@ -99,5 +99,5 @@ fn test_low_level_cli(sites: Vec<RevocationTestSite>) {
 
 const TEST_CONFIG_PATH: &str = "tmp/system-test/config.toml";
 const TEST_CONFIG: &str = "[revocation]\n\
-    cache_dir=\"tmp/system-test\"\n\
-    fetch_url=\"https://upki.rustls.dev/\"\n";
+    cache-dir = \"tmp/system-test\"\n\
+    fetch-url = \"https://upki.rustls.dev/\"\n";

--- a/upki/src/config.rs
+++ b/upki/src/config.rs
@@ -9,6 +9,7 @@ use crate::Manifest;
 
 /// `upki` configuration.
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct Config {
     /// Configuration for crlite-style revocation.
     pub revocation: RevocationConfig,
@@ -47,6 +48,7 @@ impl Config {
 
 /// Details about crlite-style revocation.
 #[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct RevocationConfig {
     /// Where to store revocation data files.
     pub cache_dir: PathBuf,

--- a/upki/tests/data/verify_non_existent_dir/config.toml
+++ b/upki/tests/data/verify_non_existent_dir/config.toml
@@ -1,3 +1,3 @@
 [revocation]
-cache_dir = "not-exist/"
-fetch_url = ""
+cache-dir = "not-exist/"
+fetch-url = ""

--- a/upki/tests/data/verify_of_empty_manifest/config.toml
+++ b/upki/tests/data/verify_of_empty_manifest/config.toml
@@ -1,3 +1,3 @@
 [revocation]
-cache_dir = "tests/data/verify_of_empty_manifest/"
-fetch_url = ""
+cache-dir = "tests/data/verify_of_empty_manifest/"
+fetch-url = ""

--- a/upki/tests/integration.rs
+++ b/upki/tests/integration.rs
@@ -58,8 +58,8 @@ fn show_config_fixpoint() {
     exit_code: 0
     ----- stdout -----
     [revocation]
-    cache_dir = "not-exist/"
-    fetch_url = ""
+    cache-dir = "not-exist/"
+    fetch-url = ""
 
     ----- stderr -----
     "#);
@@ -402,8 +402,8 @@ fn write_config(temp: &TempDir, fetch_url: &str) {
         temp.path().join("config.toml"),
         format!(
             "[revocation]\n\
-            cache_dir=\"{}\"\n\
-            fetch_url=\"{fetch_url}\"\n",
+            cache-dir=\"{}\"\n\
+            fetch-url=\"{fetch_url}\"\n",
             temp.path().display(),
         )
         .as_bytes(),


### PR DESCRIPTION
This feels more idiomatic for TOML contexts.