### PR TITLE
upki: error on unknown fields in configuration files

### DIFF
--- a/upki/src/config.rs
+++ b/upki/src/config.rs
@@ -9,7 +9,7 @@ use crate::Manifest;
 
 /// `upki` configuration.
 #[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct Config {
     /// Configuration for crlite-style revocation.
     pub revocation: RevocationConfig,
@@ -48,7 +48,7 @@ impl Config {
 
 /// Details about crlite-style revocation.
 #[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct RevocationConfig {
     /// Where to store revocation data files.
     pub cache_dir: PathBuf,

--- a/upki/tests/data/config_unknown_fields/config.toml
+++ b/upki/tests/data/config_unknown_fields/config.toml
@@ -1,0 +1,5 @@
+cache_dir = "tests/data/config_unknown_fields/"
+
+[revocation]
+cache-dir = "tests/data/config_unknown_fields/"
+fetch-url = ""

--- a/upki/tests/integration.rs
+++ b/upki/tests/integration.rs
@@ -28,6 +28,35 @@ fn version() {
 }
 
 #[test]
+fn config_unknown_fields() {
+    let _filters = apply_common_filters();
+    assert_cmd_snapshot!(
+        upki()
+            .arg("--config-file")
+            .arg("tests/data/config_unknown_fields/config.toml")
+            .arg("show-config"),
+        @r#"
+    success: false
+    exit_code: 1
+    ----- stdout -----
+
+    ----- stderr -----
+    Error: cannot parse configuration file at "tests/data/config_unknown_fields/config.toml"
+
+    Caused by:
+        TOML parse error at line 1, column 1
+          |
+        1 | cache_dir = "tests/data/config_unknown_fields/"
+          | ^^^^^^^^^
+        unknown field `cache_dir`, expected `revocation`
+
+
+    Location:
+        upki/src/config.rs:[LINE]:[COLUMN]
+    "#);
+}
+
+#[test]
 fn show_config_path_fixpoint() {
     let _filters = apply_common_filters();
     assert_cmd_snapshot!(


### PR DESCRIPTION
By default, serde ignores unknown fields, which could lead to silently ignoring fields that aren't being understood.