### PR TITLE
Use mmap to read filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1410,6 +1410,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2643,6 +2652,7 @@ dependencies = [
  "hex",
  "insta",
  "insta-cmd",
+ "memmap2",
  "rand 0.10.0",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ hex = { version = "0.4", features = ["serde"] }
 http = "1"
 insta = { version = "1.44.3", features = ["filters"] }
 insta-cmd = "0.6.0"
+memmap2 = "0.9.9"
 reqwest = { version = "0.13", default-features = false, features = ["charset", "default-tls", "h2", "http2", "json"] }
 rand = "0.10"
 regex = "1.12"

--- a/upki/Cargo.toml
+++ b/upki/Cargo.toml
@@ -16,6 +16,7 @@ clap.workspace = true
 clubcard-crlite.workspace = true
 eyre.workspace = true
 hex.workspace = true
+memmap2.workspace = true
 reqwest.workspace = true
 rustls-pki-types.workspace = true
 rustls-webpki.workspace = true

--- a/upki/src/revocation/mod.rs
+++ b/upki/src/revocation/mod.rs
@@ -74,7 +74,7 @@ impl Manifest {
         let cache_dir = config.revocation_cache_dir();
         for f in &self.filters {
             let path = cache_dir.join(&f.filename);
-            let bytes = match fs::read(&path) {
+            let bytes = match File::open(&path).and_then(|f| unsafe { memmap2::Mmap::map(&f) }) {
                 Ok(bytes) => bytes,
                 Err(error) => {
                     return Err(Error::FilterRead {


### PR DESCRIPTION
This is probably not a serious proposition (converting valid filesystem alterations into memory safety issues isn't great) but acts as a measurement that upki is performance-sensitive in this path.

I have some ideas about how to improve this in a more robust way that need a bit of investigation/measurement.

```
revocation-check        time:   [2.9656 ms 2.9855 ms 3.0063 ms]
                        change: [−51.569% −50.952% −50.331%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
```