### PR TITLE
Delay deletions of stale files

### DIFF
--- a/upki/src/revocation/fetch.rs
+++ b/upki/src/revocation/fetch.rs
@@ -75,7 +75,14 @@ pub async fn fetch(dry_run: bool, config: &Config) -> Result<ExitCode, Error> {
 
     manifest.introduce()?;
 
-    let plan = Plan::construct(&manifest, &config.revocation.fetch_url, &cache_dir)?;
+    let old_manifest = Manifest::from_config(config).ok();
+
+    let plan = Plan::construct(
+        &manifest,
+        &old_manifest,
+        &config.revocation.fetch_url,
+        &cache_dir,
+    )?;
 
     if dry_run {
         println!(
@@ -111,10 +118,12 @@ impl Plan {
     /// Form a plan of how to synchronize with the remote server.
     ///
     /// - `manifest` describes the contents of the remote server.
+    /// - `old_manifest` is an alleged current manifest, whose files are left alone.
     /// - `remote_url` is the base URL.
     /// - `local` is the path into which files are downloaded.  The caller ensures this exists.
     pub(crate) fn construct(
         manifest: &Manifest,
+        old_manifest: &Option<Manifest>,
         remote_url: &str,
         local: &Path,
     ) -> Result<Self, Error> {
@@ -155,6 +164,12 @@ impl Plan {
             }
 
             steps.push(PlanStep::download(file, remote_url, local));
+        }
+
+        if let Some(old_manifest) = &old_manifest {
+            for file in &old_manifest.files {
+                unwanted_files.remove(Path::new(&file.filename));
+            }
         }
 
         steps.push(PlanStep::SaveManifest {

--- a/upki/src/revocation/mod.rs
+++ b/upki/src/revocation/mod.rs
@@ -111,7 +111,7 @@ impl Manifest {
     /// This performs disk IO but does not perform network IO.
     pub fn verify(&self, config: &Config) -> Result<ExitCode, Error> {
         self.introduce()?;
-        let plan = Plan::construct(self, "https://.../", &config.revocation_cache_dir())?;
+        let plan = Plan::construct(self, &None, "https://.../", &config.revocation_cache_dir())?;
         match plan.download_bytes() {
             0 => Ok(ExitCode::SUCCESS),
             bytes => Err(Error::Outdated(bytes)),

--- a/upki/tests/integration.rs
+++ b/upki/tests/integration.rs
@@ -260,7 +260,38 @@ fn full_fetch_and_incremental_update() {
     GET /manifest.json  ->  200 OK (545 bytes)
     GET /filter4.delta  ->  200 OK (3 bytes)
     ");
-    // filter2 is deleted (stale), filter4 is new
+    // filter2 could be deleted, filter4 is new
+    assert_eq!(
+        list_dir(&temp.path().join("revocation")),
+        vec![
+            "filter1.filter",
+            "filter2.delta",
+            "filter3.delta",
+            "filter4.delta",
+            "manifest.json"
+        ]
+    );
+
+    // a fetch of the same manifest clears away "filter2.delta" as it is now unused
+    let (server, _filters) = http_server("tests/data/evolution/");
+    write_config(&temp, server.url());
+    assert_cmd_snapshot!(
+        upki()
+            .arg("--config-file")
+            .arg(&config_file)
+            .arg("fetch"),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    ");
+    assert_snapshot!(
+        server.into_log(),
+        @"GET /manifest.json  ->  200 OK (545 bytes)");
+
+    // filter2 is now deleted
     assert_eq!(
         list_dir(&temp.path().join("revocation")),
         vec![


### PR DESCRIPTION
The race condition that this avoids is as follows: a revocation check races a fetch.  The revocation first read the manifest, and finds files `[A, B, C]`.  Now the fetch obtains the new manifest, which contains `[B, C]`.  It saves the new manifest.  It determines file `A` is unused, so it deletes it.  Now the revocation check loads files from its (in memory manifest) and finds `A` to be missing.

We avoid this by having the fetch process avoid deleting files that are referenced by any prior manifest.

This is another component in fixing #31 