### PR TITLE
Update default revocation fetch URL

### DIFF
--- a/revoke-test/benches/data/config.toml
+++ b/revoke-test/benches/data/config.toml
@@ -1,4 +1,4 @@
 cache-dir = "benches/data/"
 
 [revocation]
-fetch-url = "https://upki.rustls.dev/"
+fetch-url = "https://upki.rustls.dev/revocation/"

--- a/revoke-test/tests/system_tests.rs
+++ b/revoke-test/tests/system_tests.rs
@@ -234,4 +234,4 @@ enum TestResult {
 const TEST_CONFIG_PATH: &str = "tmp/system-test/config.toml";
 const TEST_CONFIG: &str = "cache-dir=\"tmp/system-test\"\n\
     [revocation]\n\
-    fetch-url=\"https://upki.rustls.dev/\"\n";
+    fetch-url=\"https://upki.rustls.dev/revocation/\"\n";

--- a/upki/src/revocation/mod.rs
+++ b/upki/src/revocation/mod.rs
@@ -338,7 +338,7 @@ pub struct RevocationConfig {
 impl Default for RevocationConfig {
     fn default() -> Self {
         Self {
-            fetch_url: "https://upki.rustls.dev/".into(),
+            fetch_url: "https://upki.rustls.dev/revocation/".into(),
         }
     }
 }


### PR DESCRIPTION
This moves to using the alternative URL scheme introduced in #92 

(We could also remove the backwards-compatible stuff it added here?)