### PR TITLE
Bump versions to 1.0.0-beta.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2025,7 +2025,7 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-upki"
-version = "0.1.0"
+version = "1.0.0-beta.1"
 dependencies = [
  "rustls",
  "rustls-native-certs",
@@ -2683,7 +2683,7 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "upki"
-version = "0.2.0"
+version = "1.0.0-beta.1"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -2711,7 +2711,7 @@ dependencies = [
 
 [[package]]
 name = "upki-cli"
-version = "0.2.0"
+version = "1.0.0-beta.1"
 dependencies = [
  "clap",
  "eyre",
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "upki-openssl"
-version = "0.1.0"
+version = "1.0.0-beta.1"
 dependencies = [
  "cbindgen",
  "openssl-sys",

--- a/rustls-upki/Cargo.toml
+++ b/rustls-upki/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-upki"
-version = "0.1.0"
+version = "1.0.0-beta.1"
 license.workspace = true
 edition.workspace = true
 repository.workspace = true
@@ -9,7 +9,7 @@ rust-version.workspace = true
 [dependencies]
 rustls.workspace = true
 rustls-webpki.workspace = true
-upki = { path = "../upki" }
+upki = { version = "=1.0.0-beta.1", path = "../upki" }
 
 [dev-dependencies]
 rustls-native-certs = "0.8.3"

--- a/upki-cli/Cargo.toml
+++ b/upki-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upki-cli"
-version = "0.2.0"
+version = "1.0.0-beta.1"
 rust-version.workspace = true
 edition.workspace = true
 repository.workspace = true
@@ -12,7 +12,7 @@ description = "Platform-independent browser-grade certificate infrastructure"
 clap.workspace = true
 eyre.workspace = true
 rustls-pki-types.workspace = true
-upki = { version = "0.2", path = "../upki" }
+upki = { version = "=1.0.0-beta.1", path = "../upki" }
 tokio.workspace = true
 toml.workspace = true
 tracing.workspace = true

--- a/upki-cli/tests/integration.rs
+++ b/upki-cli/tests/integration.rs
@@ -18,14 +18,14 @@ use tempfile::TempDir;
 #[test]
 fn version() {
     let _filters = apply_common_filters();
-    assert_cmd_snapshot!(upki().arg("--version"), @r###"
+    assert_cmd_snapshot!(upki().arg("--version"), @"
     success: true
     exit_code: 0
     ----- stdout -----
-    upki 0.2.0
+    upki 1.0.0-beta.1
 
     ----- stderr -----
-    "###);
+    ");
 }
 
 #[test]

--- a/upki-openssl/Cargo.toml
+++ b/upki-openssl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upki-openssl"
-version = "0.1.0"
+version = "1.0.0-beta.1"
 license.workspace = true
 rust-version.workspace = true
 edition.workspace = true
@@ -9,7 +9,7 @@ repository.workspace = true
 [dependencies]
 openssl-sys = { workspace = true }
 rustls-pki-types.workspace = true
-upki = { path = "../upki", version = "0.2.0", features = ["capi"] }
+upki = { version = "=1.0.0-beta.1", path = "../upki", features = ["capi"] }
 
 [dev-dependencies]
 cbindgen.workspace = true

--- a/upki/Cargo.toml
+++ b/upki/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "upki"
-version = "0.2.0"
+version = "1.0.0-beta.1"
 rust-version.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Next, I'd like to push a tag to see how the release workflow works out.

We still have a git dependency on clubcard-crlite, so we can't publish to crates.io until our improvements there have been merged (although we can publish our own binaries, of course).