### PR TITLE
cli: tweak tracing-subscriber setup

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -40,7 +40,7 @@ jobs:
           target=$(cargo run --release --bin upki -- show-config-path)
           mkdir --parents $(dirname $target)
           mv config.toml $target
-          cargo run --release --bin upki -- fetch
+          RUST_LOG=debug cargo run --release --bin upki -- fetch
 
       - name: Build benchmarks
         run: cargo codspeed build -p revoke-test --features __bench_codspeed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1424,6 +1424,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2633,9 +2642,13 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "thread_local",
+ "tracing",
  "tracing-core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ tokio = { version = "1.47", features = ["io-util", "macros", "net", "rt"] }
 tokio-rustls = "0.26"
 toml = "1"
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["ansi", "env-filter", "fmt"] }
 x509-parser = "0.18"
 cbindgen = "0.29"
 webpki-ccadb = "0.2.1"

--- a/upki-cli/src/bin/upki.rs
+++ b/upki-cli/src/bin/upki.rs
@@ -19,11 +19,7 @@ use upki::{Config, ConfigPath};
 async fn main() -> Result<ExitCode, Report> {
     let args = Args::parse();
     tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::fmt::layer()
-                .with_ansi(false)
-                .compact(),
-        )
+        .with(tracing_subscriber::fmt::layer().compact())
         .with(
             EnvFilter::builder()
                 .with_default_directive(

--- a/upki-cli/src/bin/upki.rs
+++ b/upki-cli/src/bin/upki.rs
@@ -8,19 +8,34 @@ use clap::{Parser, Subcommand};
 use eyre::{Context, Report};
 use rustls_pki_types::CertificateDer;
 use rustls_pki_types::pem::PemObject;
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
 use upki::revocation::{Index, Manifest, RevocationCheckInput, fetch};
 use upki::{Config, ConfigPath};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<ExitCode, Report> {
     let args = Args::parse();
-    if args.verbose {
-        tracing_subscriber::fmt()
-            .with_max_level(tracing::Level::TRACE)
-            .with_ansi(false)
-            .compact()
-            .init();
-    }
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_ansi(false)
+                .compact(),
+        )
+        .with(
+            EnvFilter::builder()
+                .with_default_directive(
+                    match args.verbose {
+                        true => LevelFilter::TRACE,
+                        false => LevelFilter::ERROR,
+                    }
+                    .into(),
+                )
+                .from_env()?,
+        )
+        .init();
 
     let config_path =
         ConfigPath::new(args.config_file).wrap_err("cannot find configuration path")?;


### PR DESCRIPTION
* Make sure `RUST_LOG` can be used to tweak logging
* Show warning- and error-level logs even when `--verbose` is disabled
* Enable color

<img width="779" height="120" alt="Screenshot 2026-06-12 at 17 09 06" src="https://github.com/user-attachments/assets/4d90cc88-5737-4227-af2b-0f2186d9ac0a" />
