### PR TITLE
ffi: respect user default configuration

### DIFF
--- a/upki/src/ffi.rs
+++ b/upki/src/ffi.rs
@@ -108,7 +108,7 @@ pub unsafe extern "C" fn upki_config_new(
             }
         };
 
-        match Config::from_file(path.as_ref()) {
+        match Config::from_file_or_user_default(&path) {
             Ok(config) => {
                 unsafe { *out = Box::into_raw(Box::new(upki_config(config))) };
                 upki_result::UPKI_OK


### PR DESCRIPTION
This solves the issue reported on friday whereby:

- there is no configuration file
- `upki show-config` works and shows the in-memory "user default" configuration
- `upki fetch` works, and puts stuff in a sensible per-user location
- `upki revocation check` works, and uses that location
- `upki-openssl.so` fails with "curl: (60) SSL certificate problem: unspecified certificate verification error" which arises from `upki_config_new` failing.