### PR TITLE
ci: run cargo deny to check licenses/vulnerabilities

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,4 +124,4 @@ jobs:
           toolchain: "1.85"
 
       - name: Check MSRV
-        run: cargo check --locked --all-features
+        run: cargo check --locked --all-features -p upki -p rustls-upki -p upki-openssl -p upki-cli

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -61,5 +61,11 @@ jobs:
 
       - name: clang-format
         run: |
-            clang-format -i upki/ffi-example/upki-demo.c
-            git diff --exit-code
+          clang-format -i upki/ffi-example/upki-demo.c
+          git diff --exit-code
+
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: EmbarkStudios/cargo-deny-action@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,9 +646,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "directories"
@@ -1451,9 +1448,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2317,12 +2314,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -2332,15 +2328,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,17 @@
+[licenses]
+version = 2
+allow = [
+  "Apache-2.0",
+  "BSD-3-Clause",
+  "CDLA-Permissive-2.0",
+  "ISC",
+  "MIT",
+  "MPL-2.0",
+  "Unicode-3.0",
+]
+private = { ignore = true }
+
+[advisories]
+ignore = [
+  "RUSTSEC-2025-0141", # bincode is unmaintained; going away with newer CRLite versions
+]

--- a/revoke-test/Cargo.toml
+++ b/revoke-test/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 rust-version.workspace = true
 edition.workspace = true
 repository.workspace = true
+publish = false
 
 [dependencies]
 aws-lc-rs.workspace = true


### PR DESCRIPTION
We're using the MSRV-aware Cargo resolver, so it doesn't give us updates to vulnerable versions by default if the updates crosses our MSRV threshold.