### PR TITLE
Cargo: clubcard-crlite 0.5.1 -> 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "clubcard-crlite"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6c94d9aa9e9986a62176f935ea8e74cebea6570e433795c0e52d479e6ef4f15"
+checksum = "077423e546548daf83d605a1f8427fe926be6d714585a9807096a71a4b1aa984"
 dependencies = [
  "base64",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ base64 = "0.22.1"
 chrono = { version = "0.4.42", features = ["alloc"], default-features = false }
 clap = { version = "4.5", features = ["derive"] }
 clubcard = { version = "0.3.3", features = ["builder"] }
-clubcard-crlite = { version = "0.5.1", default-features = false, features = ["bincode"] }
+clubcard-crlite = { version = "0.6", default-features = false, features = ["bincode"] }
 criterion = "0.8"
 csv = "1.4"
 directories = "6"


### PR DESCRIPTION
This takes the latest `clubcard-crlite` to align on the clubcard filter version encoding/decoding (https://github.com/mozilla/clubcard-crlite/pull/32). It's wire compatible with existing filters.