### PR TITLE
cli: Add systemd user and unit definitions

### DIFF
--- a/upki-cli/systemd/upki-fetch.service
+++ b/upki-cli/systemd/upki-fetch.service
@@ -1,0 +1,48 @@
+[Unit]
+Description=upki periodic fetcher
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+
+User=upki
+Group=upki
+
+StateDirectory=upki
+StateDirectoryMode=0755
+CacheDirectory=upki/revocation
+CacheDirectoryMode=0755
+
+NoNewPrivileges=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectSystem=strict
+ProtectHome=true
+ProtectClock=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+MemoryDenyWriteExecute=true
+LockPersonality=true
+RemoveIPC=true
+ProcSubset=pid
+UMask=0022
+SystemCallArchitectures=native
+
+CapabilityBoundingSet=
+AmbientCapabilities=
+
+RestrictAddressFamilies=AF_INET AF_INET6
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+
+ExecStart=/usr/bin/upki fetch
+
+StandardOutput=journal
+StandardError=journal

--- a/upki-cli/systemd/upki-fetch.timer
+++ b/upki-cli/systemd/upki-fetch.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run upki fetch every 2 hours
+
+[Timer]
+OnBootSec=10min
+OnUnitActiveSec=2h
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/upki-cli/systemd/upki.sysusers
+++ b/upki-cli/systemd/upki.sysusers
@@ -1,0 +1,3 @@
+u upki - "upki service user" /var/lib/upki /usr/sbin/nologin
+g upki - -
+m upki upki


### PR DESCRIPTION
I don't know if you want this but it seems good to standardize the fetching services such that integration is somewhat straightforward.

> This introduces a upki-fetch timer that will regularly run the `upki fetch` command using a `upki-fetch` service.
> A `upki` user is used and the mode is set such that the data is readable for all users.

Thinking about this now as I propose it I do wonder if we can use the PrivateUser mechanism instead. 

We're pondering a bit about the AppArmor profiles [https://bugs.launchpad.net/ubuntu/+source/upki/+bug/2166514], and what is clearly unresolved is what happens if you run `upki fetch` as root yourself - it would not drop to the `upki` user.